### PR TITLE
Significant changes to message handling, plus other features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,12 @@ The group chat/CQ log is at <https://aprsph.net/cq>.
 
 # Supported bot commands
 
-- **NET (space) message** - This adds the user to the day's log (refreshes every midnight at the machine's local time). It also logs the timestamp, callsign, and message to a file that can be posted on the web. See http://aprs.dx1arm.net for example.
-- **CQ (space) message** - This sends the message to all stations currently checked into the net. It also saves the timestamp, callsign, and message to a file that can be posted on the web. See http://cq.dx1arm.net for example.
+- **CQ (space) message** - This sends the message to all stations currently checked into the net. It also saves the timestamp, callsign, and message to a file that can be posted on the web. See https://aprsph.net for example.
+- **NET (space) message** - This is a "quiet" checkin. Logs the user's callsign and message without relaying the message to everyone currently in the list for the day.
 - **LIST** - returns a list of stations currently checked into the net.
-- **LOG** - Returns the last 3 net checkins and their messages.
-- **LAST** - Returns the last 3 CQ messages
+- **LAST** - Returns the last 5 CQ messages. LAST10 and LAST15 returns 10 and 15, respectively.
+- **?APRSM** - Retrieves 5 most recent messages addressed to the user from aprs.fi (effectively a way to retrieve missed message). Alternative keywords are MSG and M. ?APRSM10, MSG10, M10 retrieves the last 10 messages. User can also add a callsign+ssid to retrieve mssages for that particular station. For example ?APRSM DU2XXR-7 retrieevs the last 5 messages sent to DU2XXR-7.
+- **IC** - Set of commands that let the user draft a longer piece of message (multiple lines), then publish these onto a web log and simultaneously sent to a pre-designated station and/or email. 
 - **SMS (space) XXXXXXXXXXX (space) Message** - Sends a text message the the number XXXXXXXXXXX along with the message. This supports replies or new messages from SMS users by sending @CALLSIGN-SSID to the gateway number. Currently, the script supports numbers in the Philippines, since that is where I operate. This requires gammu-smsd daemon. Some modems might have issue processing received messages, but I have found that setting AT+CNMI to 1,2,0,0 works.
 - **SMSALIAS (space) XXXXXXXXXXX (space) Message** - Sets an alias so that the SMS recipient/sender number will no longer appear in subsequent messages.
 - **?APRST** or **?PING?** returns the path taken by the user's current ping message to the bot. 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,15 @@ The group chat/CQ log is at <https://aprsph.net/cq>.
 
 # Supported bot commands
 
-- **CQ (space) message** - This sends the message to all stations currently checked into the net. It also saves the timestamp, callsign, and message to a file that can be posted on the web. See https://aprsph.net for example.
-- **NET (space) message** - This is a "quiet" checkin. Logs the user's callsign and message without relaying the message to everyone currently in the list for the day.
-- **LIST** - returns a list of stations currently checked into the net.
-- **LAST** - Returns the last 5 CQ messages. LAST10 and LAST15 returns 10 and 15, respectively.
-- **?APRSM** - Retrieves 5 most recent messages addressed to the user from aprs.fi (effectively a way to retrieve missed message). Alternative keywords are MSG and M. ?APRSM10, MSG10, M10 retrieves the last 10 messages. User can also add a callsign+ssid to retrieve mssages for that particular station. For example ?APRSM DU2XXR-7 retrieevs the last 5 messages sent to DU2XXR-7.
+- **CQ [space] your message** to send a message to everyone checked in for the day. This also adds you to the net log, and you will subsequently receive any CQ messages received by APRSPH thereafter. Subsequent CQ messages will also be sent to everyone in the list.
+- **NET [space] your message** will quietly join you into the daily net. This will not alert everyone in the net, but your message will be logged below. The message is optional. Sending NET without a message after will still log your callsign into the net and the recipient list.
+- **LIST** to view the current day's list of checked-in stations.
+- **LAST** to see the last 5 messages (use LAST10 for 10 messages or LAST15 for 15 messages).
+- **MINE** to view the recent CQ/NET messages sent by your own station to the net in the current month. You may include a callsign-ssid to review the last messages sent by that station (e.g., MINE DU2XXR-7). Use MINE10 or MINE15 for 10 or 15 messages, respectively.
+- **SEARCH [space] word or phrase** to find the last 5 messages from the month that contain the word or phrase. SEARCH10 or SEARCH15 to fetch 10 or 15 messages, respectively
+- **?APRST** or ?PING? to get a message with the path/s your packet took to the bot.
+- **?APRSM** or MSG to retrieve the last 5 messages sent to your callsign+ssid, using the aprs.fi API. Add a callsign-ssid after to retrieve messages directed to that callsign. Example: ?APRSM DU2XXR-7
+- **HELP** for a list of other commands.
 - **IC** - Set of commands that let the user draft a longer piece of message (multiple lines), then publish these onto a web log and simultaneously sent to a pre-designated station and/or email. 
 - **SMS (space) XXXXXXXXXXX (space) Message** - Sends a text message the the number XXXXXXXXXXX along with the message. This supports replies or new messages from SMS users by sending @CALLSIGN-SSID to the gateway number. Currently, the script supports numbers in the Philippines, since that is where I operate. This requires gammu-smsd daemon. Some modems might have issue processing received messages, but I have found that setting AT+CNMI to 1,2,0,0 works.
 - **SMSALIAS (space) XXXXXXXXXXX (space) Message** - Sets an alias so that the SMS recipient/sender number will no longer appear in subsequent messages.
@@ -86,6 +90,8 @@ The group chat/CQ log is at <https://aprsph.net/cq>.
 - **VERSION** returns the python version.
 - **HELP** returns a list of commands.
 - Commands to run server-side commands are also supported.
+
+More updated commands and instructions at https://aprsph.net.
 
 # Contact information
 - **Email**: qsl@n2rac.com

--- a/README.md
+++ b/README.md
@@ -69,20 +69,21 @@ A lot of this is trial-and-error for me, so again, please bear with me.
 
 # Supported bot commands
 
-- *NET plus message* - This adds the user to the day's log (refreshes every midnight at the machine's local time). It also logs the timestamp, callsign, and message to a file that can be posted on the web. See http://aprs.dx1arm.net for example.
-- *CQ plus message* - This sends the message to all stations currently checked into the net. It also saves the timestamp, callsign, and message to a file that can be posted on the web. See http://cq.dx1arm.net for example.
-- *List* - returns a list of stations currently checked into the net.
-- *Log* - Returns the last 3 net checkins and their messages.
-- *Last* - Returns the last 3 CQ messages
-- *SMS XXXXXXXXXXX Message* - Sends a text message the the number XXXXXXXXXXX along with the message. This supports replies or new messages from SMS users. Currently, the script is for numbers in the Philippines, since that is where I operate.
-- *SMSALIAS XXXXXXXXXXX Message* - Sets an alias so that the SMS recipient/sender number will no longer appear in subsequent messages.
-- *?APRST* or *?PING?* returns the path taken by the user's current ping message to the bot. 
-- *TIME* returns the machine's current time.
-- *VERSION* returns the python version.
-- *HELP* returns a list of commands.
+- **NET plus message** - This adds the user to the day's log (refreshes every midnight at the machine's local time). It also logs the timestamp, callsign, and message to a file that can be posted on the web. See http://aprs.dx1arm.net for example.
+- **CQ plus message** - This sends the message to all stations currently checked into the net. It also saves the timestamp, callsign, and message to a file that can be posted on the web. See http://cq.dx1arm.net for example.
+- **LIST** - returns a list of stations currently checked into the net.
+- **LOG** - Returns the last 3 net checkins and their messages.
+- **LAST** - Returns the last 3 CQ messages
+- **SMS XXXXXXXXXXX Message** - Sends a text message the the number XXXXXXXXXXX along with the message. This supports replies or new messages from SMS users by sending @CALLSIGN-SSID to the gateway number. Currently, the script is for numbers in the Philippines, since that is where I operate. This requires gammu-smsd daemon. Some modems might have issue processing received messages, but I have found that setting AT+CNMI to 1,2,0,0 works.
+- **SMSALIAS XXXXXXXXXXX Message** - Sets an alias so that the SMS recipient/sender number will no longer appear in subsequent messages.
+- **?APRST** or **?PING?** returns the path taken by the user's current ping message to the bot. 
+- **TIME** returns the machine's current time.
+- **VERSION** returns the python version.
+- **HELP** returns a list of commands.
 - Commands to run server-side commands are also supported.
 
 # Contact information
-- Email: qsl@n2rac.com
-- Telegram: jangelor
-- Web: <https://n2rac.com>
+- **Email**: qsl@n2rac.com
+- **Telegram**: jangelor
+- **Web**: <https://n2rac.com>
+- **APRS**: DU2XXR-7

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ to publish the net log on a regular basis.
 Pardon my code. My knowledge is very rudimentary, and I only modify or create
 functions as I need them. If anyone can help improve on the code and the
 logic of this script, I would very much appreciate it.
-You may reach me at qsl@n2rac.com or simply APRS message me at N2RAC-7.
+You may reach me at qsl@n2rac.com or simply APRS message me at DU2XXR-7.
 
 A lot of the items here are still poorly documented if at all. Many also
 rely on some weird or nuanced scripts or directory structures that I have
@@ -73,13 +73,13 @@ The group chat/CQ log is at <https://aprsph.net/cq>.
 
 # Supported bot commands
 
-- **NET plus message** - This adds the user to the day's log (refreshes every midnight at the machine's local time). It also logs the timestamp, callsign, and message to a file that can be posted on the web. See http://aprs.dx1arm.net for example.
-- **CQ plus message** - This sends the message to all stations currently checked into the net. It also saves the timestamp, callsign, and message to a file that can be posted on the web. See http://cq.dx1arm.net for example.
+- **NET (space) message** - This adds the user to the day's log (refreshes every midnight at the machine's local time). It also logs the timestamp, callsign, and message to a file that can be posted on the web. See http://aprs.dx1arm.net for example.
+- **CQ (space) message** - This sends the message to all stations currently checked into the net. It also saves the timestamp, callsign, and message to a file that can be posted on the web. See http://cq.dx1arm.net for example.
 - **LIST** - returns a list of stations currently checked into the net.
 - **LOG** - Returns the last 3 net checkins and their messages.
 - **LAST** - Returns the last 3 CQ messages
-- **SMS XXXXXXXXXXX Message** - Sends a text message the the number XXXXXXXXXXX along with the message. This supports replies or new messages from SMS users by sending @CALLSIGN-SSID to the gateway number. Currently, the script is for numbers in the Philippines, since that is where I operate. This requires gammu-smsd daemon. Some modems might have issue processing received messages, but I have found that setting AT+CNMI to 1,2,0,0 works.
-- **SMSALIAS XXXXXXXXXXX Message** - Sets an alias so that the SMS recipient/sender number will no longer appear in subsequent messages.
+- **SMS (space) XXXXXXXXXXX (space) Message** - Sends a text message the the number XXXXXXXXXXX along with the message. This supports replies or new messages from SMS users by sending @CALLSIGN-SSID to the gateway number. Currently, the script supports numbers in the Philippines, since that is where I operate. This requires gammu-smsd daemon. Some modems might have issue processing received messages, but I have found that setting AT+CNMI to 1,2,0,0 works.
+- **SMSALIAS (space) XXXXXXXXXXX (space) Message** - Sets an alias so that the SMS recipient/sender number will no longer appear in subsequent messages.
 - **?APRST** or **?PING?** returns the path taken by the user's current ping message to the bot. 
 - **TIME** returns the machine's current time.
 - **VERSION** returns the python version.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,29 @@ Author: Alexandre Erwin Ittner   (callsign: PP5ITT)
 Email: <alexandre@ittner.com.br>
 
 Web: <https://www.ittner.com.br>
+
+
+
+# Additional notes from Angelo 4I1RAC/N2RAC
+
+This fork of Ioreth was modified by Angelo 4I1RAC/N2RAC to support additional
+functionalities, such as a means to store callsigns from a "net" checkin
+as well as a means to forward messages to all stations checked in for the day
+It is also supported by local cron jobs on my own machine and web server
+to publish the net log on a regular basis.
+ 
+Pardon my code. My knowledge is very rudimentary, and I only modify or create
+functions as I need them. If anyone can help improve on the code and the
+logic of this script, I would very much appreciate it.
+You may reach me at qsl@n2rac.com or simply APRS message me at N2RAC-7.
+
+A lot of the items here are still poorly documented if at all. Many also
+rely on some weird or nuanced scripts or directory structures that I have
+maintained on my own machine or server, so bear with me.
+The non-indented comments are mine. The indented ones are by Alexandre.
+A lot of this is trial-and-error for me, so again, please bear with me.
+
+# Contact information
+- Email: qsl@n2rac.com
+- Telegram: jangelor
+- Web: <https://n2rac.com>

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Web: <https://www.ittner.com.br>
 
 
 
-# Additional notes from Angelo 4I1RAC/N2RAC
+# Additional notes from Angelo DU2XXR / N2RAC
 
-This fork of Ioreth was modified by Angelo 4I1RAC/N2RAC to support additional
+This fork of Ioreth was modified by Angelo DU2XXR / N2RAC to support additional
 functionalities, such as a means to store callsigns from a "net" checkin
 as well as a means to forward messages to all stations checked in for the day
 It is also supported by local cron jobs on my own machine and web server
@@ -66,6 +66,21 @@ rely on some weird or nuanced scripts or directory structures that I have
 maintained on my own machine or server, so bear with me.
 The non-indented comments are mine. The indented ones are by Alexandre.
 A lot of this is trial-and-error for me, so again, please bear with me.
+
+# Supported bot commands
+
+- *NET plus message* - This adds the user to the day's log (refreshes every midnight at the machine's local time). It also logs the timestamp, callsign, and message to a file that can be posted on the web. See http://aprs.dx1arm.net for example.
+- *CQ plus message* - This sends the message to all stations currently checked into the net. It also saves the timestamp, callsign, and message to a file that can be posted on the web. See http://cq.dx1arm.net for example.
+- *List* - returns a list of stations currently checked into the net.
+- *Log* - Returns the last 3 net checkins and their messages.
+- *Last* - Returns the last 3 CQ messages
+- *SMS XXXXXXXXXXX Message* - Sends a text message the the number XXXXXXXXXXX along with the message. This supports replies or new messages from SMS users. Currently, the script is for numbers in the Philippines, since that is where I operate.
+- *SMSALIAS XXXXXXXXXXX Message* - Sets an alias so that the SMS recipient/sender number will no longer appear in subsequent messages.
+- *?APRST* or *?PING?* returns the path taken by the user's current ping message to the bot. 
+- *TIME* returns the machine's current time.
+- *VERSION* returns the python version.
+- *HELP* returns a list of commands.
+- Commands to run server-side commands are also supported.
 
 # Contact information
 - Email: qsl@n2rac.com

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ maintained on my own machine or server, so bear with me.
 The non-indented comments are mine. The indented ones are by Alexandre.
 A lot of this is trial-and-error for me, so again, please bear with me.
 
+The net currently runs at <https://aprsph.net>. You may interact with the bot by sending APRS messages with APRSPH as the addressee.
+
+The group chat/CQ log is at <https://aprsph.net/cq>.
+
 # Supported bot commands
 
 - **NET plus message** - This adds the user to the day's log (refreshes every midnight at the machine's local time). It also logs the timestamp, callsign, and message to a file that can be posted on the web. See http://aprs.dx1arm.net for example.

--- a/ioreth/aprs.py
+++ b/ioreth/aprs.py
@@ -29,7 +29,7 @@ class Handler:
     """
 
     DEFAULT_PATH = "WIDE1-1,WIDE2-2"
-    DEFAULT_DESTINATION = "APRS"
+    DEFAULT_DESTINATION = "APZIOR"
 
     def __init__(self, callsign="XX0ABC"):
         self.callsign = callsign

--- a/ioreth/bot.py
+++ b/ioreth/bot.py
@@ -131,8 +131,11 @@ class BotAprsHandler(aprs.Handler):
 
 # Assign a message ID. We need a more elegant solution than this one. Right now, it
 # Just uses a number based on the current minute. Not very nice, but it works.
+# Multi-message sending lines below use a somehow unique ID based on the 3 chars from
+# their callsign+ssid value. Msg ID supports a total of 5 characters.
 
-        mesgid = time.strftime("%u%M")
+        mesgid = time.strftime("%M")
+        mpref = source[1:4] # this gets 3 characters from the callsign
         if len(qry_args) == 2:
             args = qry_args[1]
         random_replies = {
@@ -224,8 +227,11 @@ class BotAprsHandler(aprs.Handler):
              count = 0
              for line in lines:
                   count += 1
-                  self.send_aprs_msg(f'{line}'.replace('\n',''), sourcetrunc + "/" + args + " {" + mesgid)
-                  self.send_aprs_msg(f'{line}'.replace('\n',''), "Reply 'CQ'+text to send all on today's list. 'Log' to view." + " {398")
+# message prefix gives a somehow unique message id, which is important when sending multiple messages
+# to prevent ACK from another station inadvertently cancelling a message transmit.
+                  mespre = line[1:4]
+                  self.send_aprs_msg(line.replace('\n',''), sourcetrunc + "/" + args + " {" + mespre + mesgid)
+                  self.send_aprs_msg(line.replace('\n',''), "Reply 'CQ'+text to send all on today's list. 'Log' to view." + " {398")
                   logger.info("Sending CQ message to %s", line)
 #                  time.sleep(10)
 # Wanted to add a time delay of XX seconds per station to prevent packet storms but apparently this is not the right place.
@@ -255,7 +261,8 @@ class BotAprsHandler(aprs.Handler):
              count = 0
              for line in lines:
                   count += 1
-                  self.send_aprs_msg(f'{line}'.replace('\n',''), sourcetrunc + "/" + args + " {" + mesgid)
+                  mespre = line[1:4]
+                  self.send_aprs_msg(line.replace('\n',''), sourcetrunc + "/" + args + " {" mespre + mesgid)
                   logger.info("Sending DU message to %s", line)
              file = open(dusubslist, 'r')
              data2 = file.read()  

--- a/ioreth/bot.py
+++ b/ioreth/bot.py
@@ -35,7 +35,7 @@
 # The non-indented comments are mine. The indented ones are by Alexandre.
 # A lot of this is trial-and-error for me, so again, please bear with me.
 #
-# 2022-09-10 0123H +8
+# 2022-10-23 1500H
 
 import sys
 import time
@@ -160,13 +160,13 @@ class BotAprsHandler(aprs.Handler):
         elif qry == "version":
             self.send_aprs_msg(sourcetrunc, "Python " + sys.version.replace("\n", " "))
         elif qry == "about":
-            self.send_aprs_msg(sourcetrunc, "APRS bot by N2RAC/DU2XXR based on ioreth by PP5ITT. aprs.dx1arm.net" )
+            self.send_aprs_msg(sourcetrunc, "APRS bot by N2RAC/DU2XXR based on ioreth by PP5ITT. aprsph.net" )
         elif qry == "time":
             self.send_aprs_msg(
                 sourcetrunc, "Localtime is " + time.strftime("%Y-%m-%d %H:%M:%S %Z")
             )
         elif qry == "help":
-            self.send_aprs_msg(sourcetrunc, "NET +msg,CQ +msg,LIST,LAST,LOG,?APRST,SMS ### +msg,ABOUT,TIME,HELP")
+            self.send_aprs_msg(sourcetrunc, "NET +msg,CQ +msg,LIST,LAST,LOG,?APRST,SMS NNN +msg,ABOUT,TIME,HELP")
 
 # This part is the net checkin. It logs callsigns into a daily list, and it also logs all messages into a cumulative list posted on the web
 
@@ -197,8 +197,8 @@ class BotAprsHandler(aprs.Handler):
                       if args == "":
                          self.send_aprs_msg(sourcetrunc, "U may add txt aftr NET.CQ +text grp.LAST rvw last3.LIST view QRXlist.")
                       else:
-                         self.send_aprs_msg(sourcetrunc, "QSL " + sourcetrunc + ". CQ +text grpchat.LAST review last3.LIST view QRXlist.")
-                      self.send_aprs_msg(sourcetrunc, "Pls QRX for CQ msgs. Net renews @1600Z. aprs.dx1arm.net for info." )
+                         self.send_aprs_msg(sourcetrunc, "QSL " + sourcetrunc + ":CQ +text grpchat.LAST/LOG view last3.LIST for  QRXlist.")
+                      self.send_aprs_msg(sourcetrunc, "Pls QRX for CQ msgs. Net renews @1600Z. aprsph.net for info." )
                       logger.info("Replying to %s checkin message", sourcetrunc)
 
 # Record the message somewhere to check if next message is dupe
@@ -209,28 +209,50 @@ class BotAprsHandler(aprs.Handler):
                 g.close()
 
         elif qry == "list" or qry == "?aprsd":
+           sourcetrunc = source.replace('*','')
            timestrtxt = time.strftime("%m%d")
            if os.path.isfile(filename1):
                  file = open(filename1, 'r')
                  data21 = file.read()
                  data2 = data21.replace('\n','')
                  file.close()
-                 if len(data2) > 62:
+                 if len(data2) > 184:
+                       listbody1 = data2[0:58]
+                       listbody2 = data2[58:121]
+                       listbody3 = data2[121:184]
+                       listbody4 = data2[184:]
+                       self.send_aprs_msg(sourcetrunc, timestrtxt + " 1/4:" + listbody1 )
+                       self.send_aprs_msg(sourcetrunc, "2/4:" + listbody2 )
+                       self.send_aprs_msg(sourcetrunc, "3/4:" + listbody2 )
+                       self.send_aprs_msg(sourcetrunc, "4/4:" + listbody2 )
+                       self.send_aprs_msg(sourcetrunc, "Send CQ +text to msg all in today's log. Info: aprsph.net" )
+                       logger.info("Replying with stations heard today. Exceeded length so split into 4: %s", data2 )
+                 if len(data2) > 121 and len(data2) <= 184:
+                       listbody1 = data2[0:58]
+                       listbody2 = data2[58:121]
+                       listbody3 = data2[121:]
+                       self.send_aprs_msg(sourcetrunc, timestrtxt + " 1/3:" + listbody1 )
+                       self.send_aprs_msg(sourcetrunc, "2/3:" + listbody2 )
+                       self.send_aprs_msg(sourcetrunc, "3/3:" + listbody3 )
+                       self.send_aprs_msg(source, "Send CQ +text to msg all in today's log. Info: aprsph.net" )
+                       logger.info("Replying with stations heard today. Exceeded length so split into 3: %s", data2 )
+                 if len(data2) > 58 and len(data2) <= 121:
                        listbody1 = data2[0:58]
                        listbody2 = data2[58:]
-                       self.send_aprs_msg(source, timestrtxt + " 1/2:" + listbody1 )
-                       self.send_aprs_msg(source, "2/2:" + listbody2 )
-                       self.send_aprs_msg(source, "Send CQ +text to msg all in today's log. Info: aprs.dx1arm.net" )
+                       self.send_aprs_msg(sourcetrunc, timestrtxt + " 1/2:" + listbody1 )
+                       self.send_aprs_msg(sourcetrunc, "2/2:" + listbody2 )
+                       self.send_aprs_msg(sourcetrunc, "Send CQ +text to msg all in today's log. Info: aprsph.net" )
                        logger.info("Replying with stations heard today. Exceeded length so split into 2: %s", data2 )
-                 else:
-                       self.send_aprs_msg(source, timestrtxt + ":" + data2 )
-                       self.send_aprs_msg(source, "Send CQ +text to msg all in today's log. Info: aprs.dx1arm.net" )
+                 if len(data2) <= 58:
+                       self.send_aprs_msg(sourcetrunc, timestrtxt + ":" + data2 )
+                       self.send_aprs_msg(sourcetrunc, "Send CQ +text to msg all in today's log. Info: aprsph.net" )
                        logger.info("Replying with stations heard today: %s", data2 )
            else:
-                 self.send_aprs_msg(source, "No stations have checked in yet. NET +msg to checkin.") 
+                 self.send_aprs_msg(sourcetrunc, "No stations have checked in yet. NET +msg to checkin.") 
 
         elif qry == "cq":
            sourcetrunc = source.replace('*','')
+           cqnet = 0
 # Checking if duplicate message
            if not args == open('/home/pi/ioreth/ioreth/ioreth/lastmsg').read():
                   logger.info("Message is not exact duplicate, now logging" )
@@ -266,6 +288,7 @@ class BotAprsHandler(aprs.Handler):
                 with open('/home/pi/ioreth/ioreth/ioreth/nettext', 'w') as ntg:
                       data3 = "{} {}: {}".format(time.strftime("%Y-%m-%d %H:%M:%S %Z"), sourcetrunc, args)
                       ntg.write(data3)
+                      cqnet = 1
                       logger.info("Writing %s net message to netlog-msg", sourcetrunc)
 # Record the message somewhere to check if next message is dupe
            with open('/home/pi/ioreth/ioreth/ioreth/lastmsg', 'w') as g:
@@ -275,6 +298,7 @@ class BotAprsHandler(aprs.Handler):
 
 # Send the message to all on the QRX list for today
            lines = []
+           sourcetrunc = source.replace('*','')
            with open(filename3) as sendlist:
                 lines = sendlist.readlines()
            count = 0
@@ -292,8 +316,17 @@ class BotAprsHandler(aprs.Handler):
            daylog.close()
            dayta31 = dayta2.replace(sourcetrunc + ',','')
            dayta3 = dayta31.replace('\n','')
-           self.send_aprs_msg(source, "QSP " + dayta3 )
+#           dayta3count = dayta3.count(",")
+           if len(dayta3) > 63:
+                 self.send_aprs_msg(sourcetrunc, "QSP today's checked-in stations. LIST to view recipients." )
+           else:
+                 self.send_aprs_msg(sourcetrunc, "QSP " + dayta3 )
            logger.info("Advising %s of messages sent to %s", sourcetrunc, dayta3)
+           if cqnet == 1:
+                 self.send_aprs_msg(sourcetrunc, "UR also checked in! QRX for CQ msgs. Net refreshes 1600Z." )
+                 logger.info("Adivising %s they are also now checked in.", sourcetrunc)
+
+
 
 # This is for permanent subscribers in your QST list. 
 # Basically a fixed implementation of "CQ" but with subscribers not having any control.
@@ -502,7 +535,6 @@ class BotAprsHandler(aprs.Handler):
         elif qry == "YOURCOMMAND2" and ( source == "CALLSIGN1" or "CALLSIGN2" or  "CALLSIGN3" ):
              os.system('ssh user@otherserver sudo shutdown --reboot')
              self.send_aprs_msg(sourcetrunc, "ttfn" )
-
 
 
         else:
@@ -729,6 +761,7 @@ class ReplyBot(AprsClient):
                     else:
 # Let cell user create an alias
                       
+
                       if smsstartupper == "ALIAS":
                           cellaliasfile = "/home/pi/ioreth/ioreth/ioreth/smsalias/CELLULAR"
                           isbodyalias = len(smsreceived.split())
@@ -741,7 +774,7 @@ class ReplyBot(AprsClient):
                           with open(cellaliasfile, 'a') as makealias:
                               writealias = "{} {}\n".format(smssender, cellownalias)
                               makealias.write(writealias)
-                          sendsms = ( "echo 'U have set ur own alias as " + cellownalias + ". Ur # will not appear on APRS msgs. Go aprs.dx1arm.net for more info.' | gammu-smsd-inject TEXT 0" + smsnumber )
+                          sendsms = ( "echo 'U have set ur own alias as " + cellownalias + ". Ur # will not appear on msgs. aprs . dx1arm . net for more info.' | gammu-smsd-inject TEXT 0" + smsnumber )
                           os.system(sendsms)
                           logger.info("Self-determined alias set for for %s as %s.", smsnumber, cellownalias )
 
@@ -805,6 +838,7 @@ class ReplyBot(AprsClient):
                                if len(smsbody) >= 48 and len(smsbody) <= 110:
                                   self._aprs.send_aprs_msg(callsign[1:], "SMS " + smssender + " 1/2:" + smsbody1)
                                   self._aprs.send_aprs_msg(callsign[1:], "2/2:" + smsbody2)
+                                  self._aprs.send_aprs_msg(callsign[1:], "SMS " + smssender + " Message to send/reply to PH SMS.")
                                   logger.info("SMS too long to fit 1 APRS message. Splitting into 2.")
                                if len(smsbody) >= 111 and len(smsbody) <= 173:
                                   self._aprs.send_aprs_msg(callsign[1:], "SMS " + smssender + " 1/3:" + smsbody1)
@@ -821,17 +855,17 @@ class ReplyBot(AprsClient):
                                   logger.info("SMS too long to fit 1 APRS message. Splitting into 4.")
                           else:
                                self._aprs.send_aprs_msg(callsign[1:], "SMS " + smssender + ":" + smsbody)
-                               self._aprs.send_aprs_msg(callsign[1:], "SMS " + smssender+ " Message to send/reply to PH SMS.")
+                               self._aprs.send_aprs_msg(callsign[1:], "SMS " + smssender + " Message to send/reply to PH SMS.")
                                logger.info("SMS is in correct format. Sending to %s.", callsign)
                           if smsalias == 1 or cellsmsalias == 1:
-                               sendsms = ( "echo 'APRS msg to " + callsign[1:] + " has been sent. APRS msgs not private, but ur # has an alias & will not appear. Go aprs.dx1arm.net for more info.' | gammu-smsd-inject TEXT 0" + smsnumber )
+                               sendsms = ( "echo 'APRS msg to " + callsign[1:] + " has been sent. APRS msgs not private, but ur # has an alias & will not appear. aprs . dx1arm . net for more info.' | gammu-smsd-inject TEXT 0" + smsnumber )
                           else:
-                               sendsms = ( "echo 'APRS msg to " + callsign[1:] + " sent. Ur # & msg may appear on online services. Send ALIAS yourname to set an alias. Go aprs.dx1arm.net for more info.' | gammu-smsd-inject TEXT 0" + smsnumber )
+                               sendsms = ( "echo 'APRS msg to " + callsign[1:] + " sent. Ur # & msg may appear on online services. Send ALIAS yourname to set an alias. Go aprsph.net for more info.' | gammu-smsd-inject TEXT 0" + smsnumber )
                           logger.info("Sending %s a confirmation message that APRS message has been sent.", smssender)
                           os.system(sendsms)
                       else:
 #                          if smsalias == 1:
-                          sendsms = ( "echo 'To text APRS user: \n\n@CALSGN-SSID Message\n\nMust hv @ b4 CS (SSID optional if none). To set ur alias & mask ur cell#:\n\nALIAS myname\n\naprs.dx1arm.net for info.' | gammu-smsd-inject TEXT 0" + smsnumber )
+                          sendsms = ( "echo 'To text APRS user: \n\n@CALSGN-SSID Message\n\nMust hv @ b4 CS (SSID optional if none). To set ur alias & mask ur cell#:\n\nALIAS myname\n\naprs . dx1arm . net for info.' | gammu-smsd-inject TEXT 0" + smsnumber )
 #                          else:
 #                                sendsms = ( "echo 'Incorrect format.Use: \n\n@CALSGN-SSID Message\n\nto text APRS user. Must have @ before CS. 1/2-digit SSID optional if none.' | gammu-smsd-inject TEXT 0" + smsnumber )
 
@@ -859,14 +893,30 @@ class ReplyBot(AprsClient):
            file = open(filename1, 'r')
            data5 = file.read()  
            file.close()
-           if len(data5) > 58:
+           if len(data5) > 184:
+                       listbody1 = data5[0:58]
+                       listbody2 = data5[58:121]
+                       listbody3 = data5[121:184]
+                       listbody4 = data5[184:]
+                       self._aprs.send_aprs_msg("BLN5NET", timestrtxt + " 1/4:" + listbody1)
+                       self._aprs.send_aprs_msg("BLN6NET", "2/4:" + listbody2 )
+                       self._aprs.send_aprs_msg("BLN7NET", "3/4:" + listbody3 )
+                       self._aprs.send_aprs_msg("BLN8NET", "4/4:" + listbody4 )
+           if len(data5) > 121 and len(data5) <= 184:
+                       listbody1 = data5[0:58]
+                       listbody2 = data5[58:121]
+                       listbody3 = data5[121:]
+                       self._aprs.send_aprs_msg("BLN6NET", timestrtxt + " 1/3:" + listbody1)
+                       self._aprs.send_aprs_msg("BLN7NET", "2/3:" + listbody2 )
+                       self._aprs.send_aprs_msg("BLN8NET", "3/3:" + listbody3 )
+           if len(data5) > 58 and len(data5) <= 121:
                        listbody1 = data5[0:58]
                        listbody2 = data5[58:]
-                       self._aprs.send_aprs_msg("BLN7NET", timestrtxt + " 1/2:" + listbody1)
-                       self._aprs.send_aprs_msg("BLN8NET", "2/2:" + listbody2 )
-           else:
-                       self._aprs.send_aprs_msg("BLN7NET", timestrtxt + ":" + data5)
-           self._aprs.send_aprs_msg("BLN9NET", "Full logs at http://aprs.dx1arm.net & http://cq.dx1arm.net")
+                       self._aprs.send_aprs_msg("BLN6NET", timestrtxt + " 1/2:" + listbody1)
+                       self._aprs.send_aprs_msg("BLN7NET", "2/2:" + listbody2 )
+           if len(data5) <= 58:
+                       self._aprs.send_aprs_msg("BLN6NET", timestrtxt + ":" + data5)
+           self._aprs.send_aprs_msg("BLN9NET", "Full logs at https://aprsph.net & http://aprsph.net/cq.")
            logger.info("Sending new log text to BLN7NET to BLN8NET after copying over to daily log")
 
         if os.path.isfile('/home/pi/ioreth/ioreth/ioreth/nettext'):
@@ -880,7 +930,8 @@ class ReplyBot(AprsClient):
            logger.info("Copying latest checkin message into cumulative net log")
            os.remove('/home/pi/ioreth/ioreth/ioreth/nettext')
            logger.info("Deleting net text scratch file")
-           cmd = 'scp /home/pi/ioreth/ioreth/ioreth/netlog-msg root@radio1.dx1arm.net:/var/www/html/aprsnet'
+           cmd = 'scp /home/pi/ioreth/ioreth/ioreth/netlog-msg # your web folder details here'
+#           cmd = 'scp /home/pi/ioreth/ioreth/ioreth/netlog-msg # your web folder details here'
            os.system(cmd)
            logger.info("Uploading logfile to the web")
 
@@ -895,7 +946,8 @@ class ReplyBot(AprsClient):
            logger.info("Copying latest net or checkin message into cumulative CQ message log")
            os.remove('/home/pi/ioreth/ioreth/ioreth/cqlog/cqmesg')
            logger.info("Deleting CQ text file")
-           cmd = 'scp /home/pi/ioreth/ioreth/ioreth/cqlog/cqlog root@radio1.dx1arm.net:/var/www/html/cqlog'
+           cmd = 'scp /home/pi/ioreth/ioreth/ioreth/cqlog/cqlog # your web folder details here'
+#           cmd = 'scp /home/pi/ioreth/ioreth/ioreth/cqlog/cqlog # your web folder details here'
            os.system(cmd)
            logger.info("Uploading cq to the web")
 

--- a/ioreth/bot.py
+++ b/ioreth/bot.py
@@ -478,13 +478,13 @@ class BotAprsHandler(aprs.Handler):
                 msgbody = sourcetrunc + ":" + qry + " " + args
                 if not sourcetrunc == linetrunc:
                       if qry == "cq" :
-                         if len(msgbody) > 67 :
+                         if len(msgbodycq) > 67 :
                             msgbody1 = msgbodycq[0:61]
                             msgbody2 = msgbodycq[61:]
                             self.send_aprs_msg(linetrunc, msgbody1 + "+" )
                             self.send_aprs_msg(linetrunc, msgbody2 )
                          else:
-                            self.send_aprs_msg(linetrunc, msgbody )
+                            self.send_aprs_msg(linetrunc, msgbodycq )
 #                         self.send_aprs_msg(linetrunc, sourcetrunc + ":" + args)
                       else :
                          if len(msgbody) > 67 :

--- a/ioreth/bot.py
+++ b/ioreth/bot.py
@@ -500,5 +500,3 @@ class ReplyBot(AprsClient):
 
         if isinstance(cmd, SystemStatusCommand):
             self._aprs.send_aprs_status(cmd.status_str)
-
-

--- a/ioreth/bot.py
+++ b/ioreth/bot.py
@@ -236,7 +236,7 @@ class BotAprsHandler(aprs.Handler):
              file = open(filename1, 'r')
              data2 = file.read()  
              file.close()
-             self.send_aprs_msg(source, "QSP " + data2 + "{EE")
+             self.send_aprs_msg(source, "QSP " + data2 + "{373")
              logger.info("Advising %s of messages sent to %s", sourcetrunc, data2)
 
            else:

--- a/ioreth/bot.py
+++ b/ioreth/bot.py
@@ -662,7 +662,7 @@ class BotAprsHandler(aprs.Handler):
                   logger.info("Message is exact duplicate, stop logging" )
                   return
 
-           if not len(satnum) == 8 or not satnum.isnumeric()  :
+           if not len(satnum) == 8 or satnum.isnumeric() == False  :
                logger.info("Error validating satellite message number from %s to %s", sourcetrunc,satnum)
 #                                              1234          567890123456789012345678901 234567890123456789012345678901234567
                self.send_aprs_msg(sourcetrunc, timestrtxt + " ERROR:Use 8-digit Thuraya \# after SAT. Example:SAT 44441234. " )
@@ -1190,7 +1190,7 @@ class BotAprsHandler(aprs.Handler):
              if args == open(aliasscratch).read():
                  logger.info("Already processed alias for %s %s recently. No longer processing.", SMS_DESTINATION, SMS_ALIAS)
                  return
-             if not args[0:2] == "09" and not SMS_DESTINATION.isnumeric() :
+             if not args[0:2] == "09" or SMS_DESTINATION.isnumeric() == False :
                  self.send_aprs_msg(sourcetrunc, "SMSALIAS 09XXXXXXXXX name to set. SMS NAME to send thereafter.")
                  return
              if not os.path.isfile(aliasscratch):
@@ -1292,7 +1292,7 @@ class BotAprsHandler(aprs.Handler):
 
 # Validating the destination. In the Philippines, cell numbers start with 09XX. Adjust this accordingly.
 
-             if not SMS_DESTINATION[0:2] == "09" and not SMS_DESTINATION.isnumeric() :
+             if not SMS_DESTINATION[0:2] == "09" or SMS_DESTINATION.isnumeric() == False :
                  self.send_aprs_msg(sourcetrunc, "Num or SMSALIAS invalid. Usage:SMS 09XXXXXXXXX or alias msg. PH# only" )
                  logger.info("Replying to %s that %s is not a valid number.", sourcetrunc, SMS_DESTINATION)
                  return
@@ -1585,7 +1585,7 @@ class ReplyBot(AprsClient):
                          satnumber = satargs2.split(' ',1)[0]
                          satmesg = satargs2.split(' ',1)[1]
                          satmesgtrunc = satmesg[0:138]
-                         if not len(satnumber) == 8 or not satnumber.isnumeric()  :
+                         if not len(satnumber) == 8 or satnumber.isnumeric() == False :
                             logger.info("Error validating satellite message number from %s to %s:%s", smssender,satnumber,satmesgtrunc)
                             sendsms = ( "echo 'ERROR: Include 8-digit Thuraya number after SAT. Example: SAT 44441212 Message here. Info at aprsph dot net' | gammu-smsd-inject TEXT 0" + smsnumber )
                             os.system(sendsms)

--- a/ioreth/bot.py
+++ b/ioreth/bot.py
@@ -37,9 +37,7 @@
 #
 #
 
-from __future__ import print_function
 import sys
-sys.path.append('/home/pi/python-gsmmodem')
 import time
 import logging
 import configparser
@@ -56,10 +54,6 @@ from . import aprs
 from . import remotecmd
 from . import utils
 from os import path
-
-# This is for SMS sending feature for within DU land
-from .gsmmodem.modem import GsmModem, SentSms
-
 
 # These lines below I have added in order to provide a means for ioreth to store
 # and retrieve a list of "net" checkins on a daily basis. I did not bother to use

--- a/ioreth/bot.py
+++ b/ioreth/bot.py
@@ -1181,7 +1181,7 @@ class BotAprsHandler(aprs.Handler):
              sourcetrunc = source.replace('*','')
              callnossid = sourcetrunc.split('-', 1)[0]
              SMS_DESTINATION = args[0:11]
-             SMS_ALIAS = args[12:]
+             SMS_ALIAS = args[12:].replace(' ','')
              aliasscratch = "/home/pi/ioreth/ioreth/ioreth/smsaliasscratch/" + callnossid
              aliasfile = "/home/pi/ioreth/ioreth/ioreth/smsalias/" + callnossid
 # stop processing duplicates, since APRS sends messages multiple times.
@@ -1190,7 +1190,7 @@ class BotAprsHandler(aprs.Handler):
              if args == open(aliasscratch).read():
                  logger.info("Already processed alias for %s %s recently. No longer processing.", SMS_DESTINATION, SMS_ALIAS)
                  return
-             if not args[0:2] == "09":
+             if not args[0:2] == "09" and not SMS_DESTINATION.isnumeric() :
                  self.send_aprs_msg(sourcetrunc, "SMSALIAS 09XXXXXXXXX name to set. SMS NAME to send thereafter.")
                  return
              if not os.path.isfile(aliasscratch):
@@ -1292,7 +1292,7 @@ class BotAprsHandler(aprs.Handler):
 
 # Validating the destination. In the Philippines, cell numbers start with 09XX. Adjust this accordingly.
 
-             if not SMS_DESTINATION[0:2] == "09":
+             if not SMS_DESTINATION[0:2] == "09" and not SMS_DESTINATION.isnumeric() :
                  self.send_aprs_msg(sourcetrunc, "Num or SMSALIAS invalid. Usage:SMS 09XXXXXXXXX or alias msg. PH# only" )
                  logger.info("Replying to %s that %s is not a valid number.", sourcetrunc, SMS_DESTINATION)
                  return

--- a/ioreth/bot.py
+++ b/ioreth/bot.py
@@ -59,6 +59,10 @@ from os import path
 # These lines below I have added in order to provide a means for ioreth to store
 # and retrieve a list of "net" checkins on a daily basis. I did not bother to use
 # more intuitive names for the files, but I can perhaps do so in a later code cleanup.
+# Note that the paths are full. You may wish to include these settings in the config file
+# as part of code cleanup.
+# Also, note that "filename2" is the file that gets published to the web via cron job.
+# It is a cumulative list of checkins, which includes timestamp, callsign+ssid, and messege.
 
 timestr = time.strftime("%Y%m%d")
 filename1 = "/home/pi/ioreth/ioreth/ioreth/netlog-"+timestr


### PR DESCRIPTION
2023-03-29: Improved reply for CQ and NET messages to include timestamp to better handle clients that ignore duplicate messages (because our messages don't have msgID).

2023-04-04: Added UNSUBSCRIBE command.

2023-04-12: Added queries for retrieving #APRSThursday entries. Also improved the MINE, SEARCH commands to cover current month plus archives.

2023-04-16: Throttled self ?APRSM to 1 query per 5 minutes, since a duplicate query will result in a different response set every time because the responses will now be the last messages received. Update: Changed to 30 minutes, as of 2023-05-04.

2023-06-05: Minor fix to the SMSALIAS code to accommodate for extra spaces which results in no match.

2023-06-30: Fixes to the back-end code to deal with looping messages and garbage characters from igates that cause looping.

2023-07-04: Added support for ?APRSP and ?APRSS commands.

2023-09-04: Edits to replace brackets to avoid HTML tags in log

2024-01-11: Changed relay mechanism to include original callsign and SSID as the sender instead of APRSPH. Started to support direct logging of APRSThursday net without ANSRVR relay.